### PR TITLE
誤字、誤植の修正

### DIFF
--- a/17.yaml
+++ b/17.yaml
@@ -42,7 +42,7 @@ data:
       tolerations:
       - key: "env"
         value: "production"
-        operator: "Exists"
+        operator: "Equals"
         effect: "NoExecute"
   comment: |-
     【解説 by カサレアル】
@@ -55,8 +55,8 @@ data:
     このTolerationsを指定するには、 spec.tolerations に下記のように指定します。
       - key: "env"
         value: "production"
-        operator: "Exists"
+        operator: "Equals"
         effect: "NoExecute"
-    operator には Exists （KeyとValueが等しい）または Equals （Keyが存在する）を指定可能です。
+    operator には Equals （KeyとValueが等しい）または Exists （Keyが存在する）を指定可能です。
   author: |-
     Masaya Aoyama (@amsy810)

--- a/9.yaml
+++ b/9.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   question: |-
     永続化領域として確保されるVolumeが、PersistentVolumeです。
-    NFSを使用してcndt-pvという名前のPersistentVolumeを作成し、NFSサーバのIPが192.168.9.8、容量が8Gi、アクセスモードがRXW、Reclaim PolicyがRetain、パスが/var/lib/cndtとなるように以下マニフェストファイルを変更してください。
+    NFSを使用してcndt-pvという名前のPersistentVolumeを作成し、NFSサーバのIPが192.168.9.8、容量が8Gi、アクセスモードがRWX、Reclaim PolicyがRetain、パスが/var/lib/cndtとなるように以下マニフェストファイルを変更してください。
 
     apiVersion: v1
     kind: PersistentVolume


### PR DESCRIPTION
`tolerations.operator`の`Equals`と`Exists`が逆になっていた部分を修正しました。

9.yaml のtypoを修正しました。